### PR TITLE
Add build guide on README

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -23,6 +23,11 @@ replace (
 	k8s.io/legacy-cloud-providers => github.com/kubernetes/kubernetes/staging/src/k8s.io/legacy-cloud-providers v0.0.0-20190816231410-2d3c76f9091b
 	k8s.io/metrics => github.com/kubernetes/kubernetes/staging/src/k8s.io/metrics v0.0.0-20190816231410-2d3c76f9091b
 	k8s.io/sample-apiserver => github.com/kubernetes/kubernetes/staging/src/k8s.io/sample-apiserver v0.0.0-20190816231410-2d3c76f9091b
+	modernc.org/cc => github.com/cznic/cc v0.0.0-20181122101902-d673e9b70d4d
+	modernc.org/golex => github.com/cznic/golex v0.0.0-20181122101858-9c343928389c
+	modernc.org/mathutil => github.com/cznic/mathutil v0.0.0-20181122101859-297441e03548
+	modernc.org/strutil => github.com/cznic/strutil v0.0.0-20181122101858-275e90344537
+	modernc.org/xc => github.com/cznic/xc v0.0.0-20181122101856-45b06973881e
 	tkestack.io/nvml => github.com/tkestack/go-nvml v0.0.0-20191112083529-e26e44cafb1c
 )
 
@@ -30,6 +35,7 @@ require (
 	github.com/coreos/go-systemd v0.0.0-20180511133405-39ca1b05acc7
 	github.com/docker/docker v0.7.3-0.20190327010347-be7ac8be2ae0
 	github.com/fsnotify/fsnotify v1.4.7
+	github.com/gogo/protobuf v1.1.1 // indirect
 	github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b
 	github.com/golang/protobuf v1.3.2
 	github.com/grpc-ecosystem/grpc-gateway v1.12.1

--- a/go.sum
+++ b/go.sum
@@ -77,6 +77,11 @@ github.com/coreos/rkt v1.30.0/go.mod h1:O634mlH6U7qk87poQifK6M2rsFNt+FyUTWNMnP1h
 github.com/cpuguy83/go-md2man v1.0.4/go.mod h1:N6JayAiVKtlHSnuTCeuLSQVs75hb8q+dYQLjr7cDsKY=
 github.com/cyphar/filepath-securejoin v0.0.0-20170720062807-ae69057f2299 h1:2pOMM/RaFhI52FyCITl8aTf5HZ9LoHD8SkjbghAEG1E=
 github.com/cyphar/filepath-securejoin v0.0.0-20170720062807-ae69057f2299/go.mod h1:FpkQEhXnPnOthhzymB7CGsFk2G9VLXONKD9G7QGMM+4=
+github.com/cznic/cc v0.0.0-20181122101902-d673e9b70d4d/go.mod h1:m3fD/V+XTB35Kh9zw6dzjMY+We0Q7PMf6LLIC4vuG9k=
+github.com/cznic/golex v0.0.0-20181122101858-9c343928389c/go.mod h1:+bmmJDNmKlhWNG+gwWCkaBoTy39Fs+bzRxVBzoTQbIc=
+github.com/cznic/mathutil v0.0.0-20181122101859-297441e03548/go.mod h1:e6NPNENfs9mPDVNRekM7lKScauxd5kXTr1Mfyig6TDM=
+github.com/cznic/strutil v0.0.0-20181122101858-275e90344537/go.mod h1:AHHPPPXTw0h6pVabbcbyGRK1DckRn7r/STdZEeIDzZc=
+github.com/cznic/xc v0.0.0-20181122101856-45b06973881e/go.mod h1:3oFoiOvCDBYH+swwf5+k/woVmWy7h1Fcyu8Qig/jjX0=
 github.com/d2g/dhcp4 v0.0.0-20170904100407-a1d1b6c41b1c/go.mod h1:Ct2BUK8SB0YC1SMSibvLzxjeJLnrYEVLULFNiHY9YfQ=
 github.com/d2g/dhcp4client v0.0.0-20170829104524-6e570ed0a266/go.mod h1:j0hNfjhrt2SxUOw55nL0ATM/z4Yt3t2Kd1mW34z5W5s=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=


### PR DESCRIPTION
Replace following modules to github.com, because go mod cannot fetch the data from modernc.org
  modernc.org/cc => github.com/cznic/cc v0.0.0-20181122101902-d673e9b70d4d
  modernc.org/golex => github.com/cznic/golex v0.0.0-20181122101858-9c343928389c
  modernc.org/mathutil => github.com/cznic/mathutil v0.0.0-20181122101859-297441e03548
  modernc.org/strutil => github.com/cznic/strutil v0.0.0-20181122101858-275e90344537
  modernc.org/xc => github.com/cznic/xc v0.0.0-20181122101856-45b06973881e

fix #5 
@mYmNeo 