### PR TITLE
fix: skip symlink when copy bin to |${NV_DIR}|.

### DIFF
--- a/build/copy-bin-lib.sh
+++ b/build/copy-bin-lib.sh
@@ -29,6 +29,10 @@ function copy_lib() {
 
 function copy_bin() {
   for target in $(find /usr -name "${1}"); do
+    if [[ -L ${target} ]]; then
+      echo ${target} " is symlink"
+      continue
+    fi
     copy_directory ${target} "${NV_DIR}/bin/"
   done
 }

--- a/build/copy-bin-lib.sh
+++ b/build/copy-bin-lib.sh
@@ -30,7 +30,7 @@ function copy_lib() {
 function copy_bin() {
   for target in $(find ${FIND_BASE} -name "${1}"); do
     if [[ -L ${target} ]]; then
-      echo ${target} " is symlink"
+      echo "${target} is symlink"
       continue
     fi
     copy_directory ${target} "${NV_DIR}/bin/"

--- a/build/copy-bin-lib.sh
+++ b/build/copy-bin-lib.sh
@@ -20,7 +20,7 @@ function check_arch() {
 }
 
 function copy_lib() {
-  for target in $(find /usr -name "${1}*" | grep -v "stubs"); do
+  for target in $(find ${FIND_BASE} -name "${1}*" | grep -v "stubs"); do
     if [[ $(objdump -p ${target} 2>/dev/null | grep -o "SONAME") == "SONAME" ]]; then
       copy_directory ${target} "${NV_DIR}/lib$(check_arch ${target})"
     fi
@@ -28,7 +28,7 @@ function copy_lib() {
 }
 
 function copy_bin() {
-  for target in $(find /usr -name "${1}"); do
+  for target in $(find ${FIND_BASE} -name "${1}"); do
     if [[ -L ${target} ]]; then
       echo ${target} " is symlink"
       continue


### PR DESCRIPTION
to fix the error like:
`copy /usr/local/host/lib/nvidia-440/bin/nvidia-smi to /usr/local/nvidia/bin/
cp: not writing through dangling symlink '/usr/local/nvidia/bin/nvidia-smi'`
