### PR TITLE
fix spelling mistakes in gpu-manager.yaml

### DIFF
--- a/gpu-manager.yaml
+++ b/gpu-manager.yaml
@@ -32,7 +32,7 @@ spec:
       # be rescheduled after a failure.
       # See https://kubernetes.io/docs/tasks/administer-cluster/guaranteed-scheduling-critical-addon-pods/
       priorityClassName: "system-node-critical"
-      # only run node hash gpu device
+      # only run node has gpu device
       nodeSelector:
         nvidia-device-enable: enable
       hostPID: true


### PR DESCRIPTION
`only run node hash gpu device`
to
`only run node has gpu device`