### PR TITLE
fix the mismatch between gpu-manager pick up and gpu-admission predicate

### DIFF
--- a/pkg/device/nvidia/sort.go
+++ b/pkg/device/nvidia/sort.go
@@ -19,6 +19,8 @@ package nvidia
 
 import (
 	"sort"
+
+	"tkestack.io/gpu-manager/pkg/types"
 )
 
 //LessFunc represents funcion to compare two NvidiaNode
@@ -57,7 +59,7 @@ var (
 
 	//ByAllocatableMemory compares two NvidiaNode by available memory
 	ByAllocatableMemory = func(p1, p2 *NvidiaNode) bool {
-		return p1.AllocatableMeta.Memory < p2.AllocatableMeta.Memory
+		return p1.AllocatableMeta.Memory/types.MemoryBlockSize < p2.AllocatableMeta.Memory/types.MemoryBlockSize
 	}
 
 	//PrintSorter is used to sort nodes when printing them out

--- a/pkg/device/nvidia/sort_test.go
+++ b/pkg/device/nvidia/sort_test.go
@@ -44,9 +44,9 @@ GPU4     SOC     SOC     SOC     SOC      X      PIX
 GPU5     SOC     SOC     SOC     SOC     PIX      X
 `
 	tree.Init(testCase1)
-	for _, n := range tree.Leaves() {
+	for idx, n := range tree.Leaves() {
 		n.AllocatableMeta.Cores = HundredCore
-		n.AllocatableMeta.Memory = 1024
+		n.AllocatableMeta.Memory = 1024 - int64(idx)
 	}
 
 	//test sort
@@ -57,8 +57,8 @@ GPU5     SOC     SOC     SOC     SOC     PIX      X
 		less: []LessFunc{ByAllocatableCores,
 			ByAvailable,
 			ByType,
-			ByID,
 			ByAllocatableMemory,
+			ByID,
 			ByPids,
 			ByMemory},
 	}


### PR DESCRIPTION
```
|---PHB (aval: 2, pids: [], usedMemory: 0, totalMemory: 35162423296, allocatableCores: 0, allocatableMemory: 0)
|   |---GPU0 (pids: [], usedMemory: 0, totalMemory: 11721506816, allocatableCores: 0, allocatableMemory: 0)
|   |---GPU1 (pids: [], usedMemory: 0, totalMemory: 11721506816, allocatableCores: 100, allocatableMemory: 11721506816)
|   |---GPU2 (pids: [], usedMemory: 0, totalMemory: 11719409664, allocatableCores: 100, allocatableMemory: 11719409664)
```

In my case, the total memory of GPU2 (11719409664) is less than GPU1 (11721506816).
So that even if the two GPUs are not allocated, gpu-manager will pick up GPU2 and gpu-admission will predicate GPU1, which leads to mismatch.
We can divide AllocatableMemory by 256 MB (types.MemoryBlockSize) first. And then compare the results.