### PR TITLE
Add libnvidia-gpucomp to the list of NVIDIA driver libraries

### DIFF
--- a/build/volume.conf
+++ b/build/volume.conf
@@ -42,7 +42,8 @@
           "libnvidia-glcore.so",
           "libnvidia-tls.so",
           "libnvidia-glsi.so",
-          "libnvidia-opticalflow.so"
+          "libnvidia-opticalflow.so",
+          "libnvidia-gpucomp.so"
         ]
       }
     },


### PR DESCRIPTION
Upcoming versions of the NVIDIA driver will include a new component:

https://forums.developer.nvidia.com/t/new-driver-component-libnvidia-gpucomp/267060

Update the list of NVIDIA driver libraries so that it can be included in the runtime environment along with the others.