### PR TITLE
fix: list with resourceVersion=0

### DIFF
--- a/pkg/services/allocator/nvidia/allocator.go
+++ b/pkg/services/allocator/nvidia/allocator.go
@@ -1184,6 +1184,7 @@ func getPodsOnNode(client kubernetes.Interface, hostname string, phase string) (
 		podList, err = client.CoreV1().Pods(v1.NamespaceAll).List(metav1.ListOptions{
 			FieldSelector: selector.String(),
 			LabelSelector: labels.Everything().String(),
+			ResourceVersion: "0",
 		})
 		if err != nil {
 			return false, err


### PR DESCRIPTION
list with resourceVersion=0 to optimize query performance and prevent excessive read pressure on etcd in very large-scale clusters (too many nodes).